### PR TITLE
Added constructor for linear interpolator without arguments

### DIFF
--- a/src/math/interpolation/linear_interpolation.jl
+++ b/src/math/interpolation/linear_interpolation.jl
@@ -4,6 +4,22 @@ mutable struct LinearInterpolation <: Interpolation
   s::Vector{Float64}
 end
 
+"""
+initialize without data, e.g. for usage in curve constructors
+
+Example:
+
+QuantLib.InterpolatedDiscountCurve(curve_dates, curve_values, daycount,
+        QuantLib.Math.LinearInterpolation())
+"""
+function LinearInterpolation()
+  x_vals = Vector{Float64}()
+  y_vals = Vector{Float64}()
+  s = Vector{Float64}()
+
+  QuantLib.Math.LinearInterpolation(x_vals, y_vals, s)
+end
+
 # Linear initialize
 function initialize!(interp::LinearInterpolation, x_vals::Vector{Float64}, y_vals::Vector{Float64})
   interp.x_vals = x_vals

--- a/test/curves.jl
+++ b/test/curves.jl
@@ -1,0 +1,26 @@
+using Dates
+
+effective_date = Date(2020, 01, 15)
+
+days = [369, 462, 553, 735, 1100, 1465]
+df = [0.97678403, 0.97153083, 0.96655364, 0.95695995, 0.93829085, 0.91954718]
+test_date = effective_date + Day(900)
+
+const dc_act_360 = QuantLib.Time.Actual360()
+
+# test log-linear interpolation
+test_curve_loglinear = QuantLib.InterpolatedDiscountCurve(effective_date .+ Day.(days), df, dc_act_360, QuantLib.Math.LogLinear())
+disc_factor = QuantLib.discount(test_curve_loglinear, test_date)
+x1 = (test_date - test_curve_loglinear.dates[4]).value
+dx = (test_curve_loglinear.dates[5]-test_curve_loglinear.dates[4]).value
+dy = log(test_curve_loglinear.data[5]) - log(test_curve_loglinear.data[4])
+df_recalc = exp(log(test_curve_loglinear.data[4]) + x1*dy/dx)
+@test disc_factor == df_recalc
+
+test_curve_linear = QuantLib.InterpolatedDiscountCurve(effective_date .+ Day.(days), df, dc_act_360, QuantLib.Math.LinearInterpolation())
+disc_factor = QuantLib.discount(test_curve_linear, test_date)
+x1 = (test_date - test_curve_linear.dates[4]).value
+dx = (test_curve_linear.dates[5]-test_curve_linear.dates[4]).value
+dy = (test_curve_linear.data[5]) - (test_curve_linear.data[4])
+df_recalc = ((test_curve_linear.data[4]) + x1*dy/dx)
+@test disc_factor == df_recalc

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,7 +7,8 @@ tests = ["cash_flows",
         "options",
         "swaps",
         "swaptions",
-        "fd_mesher"]
+        "fd_mesher",
+        "curves"]
 
 println("Running tests:")
 


### PR DESCRIPTION
Added constructor without arguments for linear interpolator (e.g. for usage in curve constructors). This is similar to the already existing parameter-less constructor for LogLinear.
I found it useful for QuantLib.InterpolatedDiscountCurve, when the curve is not a discount curve but e.g. a FX forward curve.
Added test cases for linear and log-linear interpolation.